### PR TITLE
Fix EnsureMage to work with go modules

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,11 +12,13 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.14.1'
+      - name: Install Mage
+        run: go run mage.go EnsureMage
       - name: Run Tests in Bash
-        run: |
-          export TEST_SHELL=bash
-          go run mage.go test
+        run: mage test
         shell: bash
+        env:
+          TEST_SHELL: bash
   test-windows:
     runs-on: windows-latest
     steps:
@@ -24,19 +26,20 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.14.1'
+      - name: Install Mage
+        run: go run mage.go EnsureMage
       - name: Run Mage in CMD
-        run: |
-          SET TEST_SHELL=cmd
-          go run mage.go test
+        run: mage test
         shell: cmd
+        env:
+          TEST_SHELL: cmd
       - name: Run Mage in PowerShell
-        run: |
-          $env:TEST_SHELL="powershell"
-          go run mage.go test
+        run: mage test
         shell: powershell
+        env:
+          TEST_SHELL: powershell
       - name: Run Mage in Git Bash
-        run: |
-          export TEST_SHELL=mingw64
-          go run mage.go test
+        run: mage test
         shell: bash
-
+        env:
+          TEST_SHELL: mingw64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/carolynvs/magex
 
-go 1.13
+go 1.15
 
 require (
 	github.com/magefile/mage v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/carolynvs/mage v1.10.1-0.20210115194910-75749aa34e48 h1:llehFuQkH9xV2cWS9CqedZGcxwLc70JRPskJoM8r+o0=
-github.com/carolynvs/mage v1.10.1-0.20210115194910-75749aa34e48/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=

--- a/magefile.go
+++ b/magefile.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/xplat"
 	"github.com/magefile/mage/sh"
 )
@@ -14,4 +15,8 @@ var Default = Test
 func Test() error {
 	fmt.Println("Running tests on", xplat.DetectShell())
 	return sh.RunV("go", "test", "-v", "./...")
+}
+
+func EnsureMage() error {
+	return pkg.EnsureMage("v1.11.0")
 }


### PR DESCRIPTION
With go modules, go get does not clone the repository to GOPATH/src. So I have switched to using git clone in a temporary directory. I am not using go get to install mage because you lose the version information.