### PR TITLE
Fix copying over an existing directory

### DIFF
--- a/shx/copy.go
+++ b/shx/copy.go
@@ -28,12 +28,17 @@ func Copy(src string, dest string, opts ...CopyOption) error {
 	}
 
 	if len(items) == 0 {
-		return errors.Errorf("no such file or directory %q", src)
+		return errors.Errorf("no such file or directory '%s'", src)
 	}
 
 	var combinedOpts CopyOption
 	for _, opt := range opts {
 		combinedOpts |= opt
+	}
+
+	// Check if the destination exists, e.g. if we are copying to /tmp/foo, /tmp should already exist
+	if _, err := os.Stat(filepath.Dir(dest)); err != nil {
+		return err
 	}
 
 	for _, item := range items {
@@ -71,7 +76,7 @@ func copyFileOrDirectory(src string, dest string, opts CopyOption) error {
 		destPath := filepath.Join(dest, relPath)
 
 		if srcInfo.IsDir() {
-			return os.Mkdir(destPath, srcInfo.Mode())
+			return os.MkdirAll(destPath, srcInfo.Mode())
 		}
 
 		return copyFile(srcPath, destPath, opts)

--- a/shx/copy_test.go
+++ b/shx/copy_test.go
@@ -27,6 +27,24 @@ func TestCopy(t *testing.T) {
 		assertFile(t, filepath.Join(tmp, "a/ab/ab2.txt"))
 	})
 
+	t.Run("recursively copy directory into populated dest dir", func(t *testing.T) {
+		tmp, err := ioutil.TempDir("", "magex")
+		require.NoError(t, err, "could not create temp directory for test")
+		defer os.RemoveAll(tmp)
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "a"), 0755))
+
+		err = Copy("testdata/copy/a", tmp, CopyRecursive)
+		require.NoError(t, err, "Copy into directory with same directory name")
+
+		assert.DirExists(t, filepath.Join(tmp, "a"))
+		assertFile(t, filepath.Join(tmp, "a/a1.txt"))
+		assertFile(t, filepath.Join(tmp, "a/a2.txt"))
+		assert.DirExists(t, filepath.Join(tmp, "a/ab"))
+		assertFile(t, filepath.Join(tmp, "a/ab/ab1.txt"))
+		assertFile(t, filepath.Join(tmp, "a/ab/ab2.txt"))
+	})
+
 	t.Run("copy glob", func(t *testing.T) {
 		tmp, err := ioutil.TempDir("", "magex")
 		require.NoError(t, err, "could not create temp directory for test")


### PR DESCRIPTION
When I run `cp -R somedir otherdir/` and otherdir/somedir already exists, copy should not fail trying to create the directory and should continue to copy children into the existing directory instead.

