### PR TITLE
Improve error message when template fails to render

### DIFF
--- a/pkg/archive/install.go
+++ b/pkg/archive/install.go
@@ -51,7 +51,7 @@ func ExtractBinaryFromArchiveHook(opts DownloadArchiveOptions) downloads.PostDow
 		opts.Ext = xplat.FileExt()
 		targetFile, err := downloads.RenderTemplate(opts.TargetFileTemplate, opts.DownloadOptions)
 		if err != nil {
-			return "", errors.Wrapf(err, "error rendering TargetFileTemplate")
+			return "", errors.Wrapf(err, "error rendering TargetFileTemplate %q with data %#v", opts.TargetFileTemplate, opts.DownloadOptions)
 		}
 
 		log.Printf("extracting %s from %s...\n", targetFile, archiveFile)


### PR DESCRIPTION
Print the template and data passed when the template doesn't render