### PR TITLE
Fix overwriting files with shx.Copy

### DIFF
--- a/shx/copy.go
+++ b/shx/copy.go
@@ -97,7 +97,7 @@ func copyFile(src string, dest string, opts CopyOption) error {
 
 	// Check if we should skip existing files
 	overwrite := opts&CopyNoOverwrite != CopyNoOverwrite
-	createOpts := os.O_CREATE | os.O_WRONLY
+	createOpts := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if !overwrite { // Return an error if the file exists
 		createOpts |= os.O_EXCL
 	}

--- a/shx/copy_test.go
+++ b/shx/copy_test.go
@@ -32,7 +32,8 @@ func TestCopy(t *testing.T) {
 		require.NoError(t, err, "could not create temp directory for test")
 		defer os.RemoveAll(tmp)
 
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "a"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "a"), 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "a/a1.txt"), []byte("a lot of extra data that should be overwritten"), 0600))
 
 		err = Copy("testdata/copy/a", tmp, CopyRecursive)
 		require.NoError(t, err, "Copy into directory with same directory name")


### PR DESCRIPTION
I wasn't truncating the file if it already existed, so existing contents would appear at the end of the file.