### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.15
 require (
 	github.com/magefile/mage v1.11.0
 	github.com/mholt/archiver/v3 v3.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/pierrec/lz4/v4 v4.0.3 h1:vNQKSVZNYUEAvRY9FaUXAF1XPbSOHJtDTiP41kzDz2E=
 github.com/pierrec/lz4/v4 v4.0.3/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/gopath/gopath.go
+++ b/pkg/gopath/gopath.go
@@ -1,6 +1,7 @@
 package gopath
 
 import (
+	"fmt"
 	"go/build"
 	"io/ioutil"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/carolynvs/magex/xplat"
-	"github.com/pkg/errors"
 )
 
 // EnsureGopathBin ensures that GOPATH/bin exists and is in PATH.
@@ -17,7 +17,7 @@ func EnsureGopathBin() error {
 	gopathBin := GetGopathBin()
 	err := os.MkdirAll(gopathBin, 0755)
 	if err != nil {
-		errors.Wrapf(err, "could not create GOPATH/bin at %s", gopathBin)
+		return fmt.Errorf("could not create GOPATH/bin at %s: %w", gopathBin, err)
 	}
 	xplat.EnsureInPath(GetGopathBin())
 	return nil
@@ -43,7 +43,7 @@ func UseTempGopath() (error, func()) {
 	oldpath := os.Getenv("PATH")
 	tmp, err := ioutil.TempDir("", "magex")
 	if err != nil {
-		return errors.Wrap(err, "Failed to create a temp directory"), func() {}
+		return fmt.Errorf("failed to create a temp directory: %w", err), func() {}
 	}
 
 	cleanup := func() {

--- a/shx/copy.go
+++ b/shx/copy.go
@@ -1,11 +1,10 @@
 package shx
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 type CopyOption int
@@ -28,7 +27,7 @@ func Copy(src string, dest string, opts ...CopyOption) error {
 	}
 
 	if len(items) == 0 {
-		return errors.Errorf("no such file or directory '%s'", src)
+		return fmt.Errorf("no such file or directory '%s'", src)
 	}
 
 	var combinedOpts CopyOption
@@ -71,7 +70,7 @@ func copyFileOrDirectory(src string, dest string, opts CopyOption) error {
 
 		relPath, err := filepath.Rel(src, srcPath)
 		if err != nil {
-			return errors.Wrapf(err, "error determining the relative path between %s and %s", src, srcPath)
+			return fmt.Errorf("error determining the relative path between %s and %s: %w", src, srcPath, err)
 		}
 		destPath := filepath.Join(dest, relPath)
 
@@ -113,7 +112,7 @@ func copyFile(src string, dest string, opts CopyOption) error {
 
 	_, err = io.Copy(destF, srcF)
 	if err != nil {
-		errors.Wrapf(err, "error copying %s to %s", src, dest)
+		fmt.Errorf("error copying %s to %s: %w", src, dest, err)
 	}
 	return destF.Close()
 }

--- a/shx/prepared_command.go
+++ b/shx/prepared_command.go
@@ -12,7 +12,6 @@ import (
 	"github.com/carolynvs/magex/mgx"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 )
 
 type PreparedCommand struct {
@@ -43,7 +42,7 @@ func (c PreparedCommand) Must(stopOnError ...bool) PreparedCommand {
 	case 1:
 		c.StopOnError = stopOnError[0]
 	default:
-		mgx.Must(errors.Errorf("More than one value for Must(stopOnError ...string) was passed to the command %s", c))
+		mgx.Must(fmt.Errorf("More than one value for Must(stopOnError ...string) was passed to the command %s", c))
 	}
 	return c
 }


### PR DESCRIPTION
This removes the direct `github.com/pkg/errors` dependency while using the native golang error wrapping.