### PR TITLE
pkg: swtich from go get to go install when installing a go package

### DIFF
--- a/pkg/install.go
+++ b/pkg/install.go
@@ -82,7 +82,7 @@ func InstallPackage(pkg string, version string) error {
 	}
 
 	fmt.Printf("Installing %s%s\n", cmd, moduleVersion)
-	err := shx.Command("go", "get", "-u", pkg+moduleVersion).
+	err := shx.Command("go", "install", pkg+moduleVersion).
 		Env("GO111MODULE=on").In(os.TempDir()).RunE()
 	if err != nil {
 		return err


### PR DESCRIPTION
Newer version of go has deprecated `go get` when installing a go package outside a module.
This PR fixes that problem by using `go install`