### PR TITLE
Support installing latest with EnsurePackage

### DIFF
--- a/pkg/install_test.go
+++ b/pkg/install_test.go
@@ -42,14 +42,30 @@ func TestGetCommandName(t *testing.T) {
 	})
 }
 
-func TestEnsurePackage_MajorVersion(t *testing.T) {
+func TestEnsurePackage(t *testing.T) {
 	os.Setenv(mg.VerboseEnv, "true")
-	err, cleanup := gopath.UseTempGopath()
-	require.NoError(t, err, "Failed to set up a temporary GOPATH")
-	defer cleanup()
+	defer os.Unsetenv(mg.VerboseEnv)
 
-	hasCmd, err := IsCommandAvailable("testpkg", "")
-	require.False(t, hasCmd)
-	err = EnsurePackage("github.com/carolynvs/testpkg/v2", "v2.0.1", "--version")
-	require.NoError(t, err)
+	testcases := []struct {
+		name    string
+		version string
+	}{
+		{name: "with prefix", version: "v2.0.1"},
+		{name: "without prefix", version: "2.0.1"},
+		{name: "no version", version: ""},
+		{name: "latest version", version: "latest"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err, cleanup := gopath.UseTempGopath()
+			require.NoError(t, err, "Failed to set up a temporary GOPATH")
+			defer cleanup()
+
+			hasCmd, err := IsCommandAvailable("testpkg", "")
+			require.False(t, hasCmd)
+			err = EnsurePackage("github.com/carolynvs/testpkg/v2", tc.version, "--version")
+			require.NoError(t, err)
+		})
+	}
 }

--- a/shx/prepared_command_test.go
+++ b/shx/prepared_command_test.go
@@ -38,8 +38,8 @@ func TestPreparedCommand_Run_Fail(t *testing.T) {
 		t.Fatal("expected shx.Command to fail")
 	}
 
-	wantStderr := "go run: no go files listed\n"
-	assert.Equal(t, wantStderr, gotStderr)
+	wantStderr := "no go files listed"
+	assert.Contains(t, gotStderr, wantStderr)
 }
 
 func TestPreparedCommand_Run_Verbose(t *testing.T) {
@@ -91,8 +91,8 @@ func TestPreparedCommand_RunE_Fail(t *testing.T) {
 		t.Fatal("expected the shx.Command to fail")
 	}
 
-	wantStderr := "go run: no go files listed\n"
-	assert.Equal(t, wantStderr, gotStderr)
+	wantStderr := "no go files listed"
+	assert.Contains(t, gotStderr, wantStderr)
 }
 
 func TestPreparedCommand_RunE_Verbose(t *testing.T) {
@@ -217,8 +217,8 @@ func TestPreparedCommand_Output_Fail(t *testing.T) {
 		t.Fatal("expected shx.Command to fail")
 	}
 
-	wantStderr := "go run: no go files listed\n"
-	assert.Equal(t, wantStderr, gotStderr)
+	wantStderr := "no go files listed"
+	assert.Contains(t, gotStderr, wantStderr)
 	assert.Empty(t, gotOutput)
 }
 
@@ -276,8 +276,8 @@ func TestPreparedCommand_OutputE_Fail(t *testing.T) {
 		t.Fatal("expected the shx.Command to fail")
 	}
 
-	wantStderr := "go run: no go files listed\n"
-	assert.Equal(t, wantStderr, gotStderr)
+	wantStderr := "no go files listed"
+	assert.Contains(t, gotStderr, wantStderr)
 	assert.Empty(t, gotOutput)
 }
 


### PR DESCRIPTION
Originally EnsurePackage was written for the older go get behavior. Now that we are using go install, the required syntax is a bit different, for example when a version is not specified, we should use @latest. I've also made it easier for people to specify the version both with and
without the v prefix, and allow for them specifying either an empty version or latest.