### PR TITLE
Handle http error during download

### DIFF
--- a/pkg/downloads/download.go
+++ b/pkg/downloads/download.go
@@ -84,6 +84,9 @@ func DownloadToGopathBin(opts DownloadOptions) error {
 		return fmt.Errorf("could not resolve %s: %w", src, err)
 	}
 	defer r.Body.Close()
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("error downloading %s (%d): %s", src, r.StatusCode, r.Status)
+	}
 
 	f, err := os.OpenFile(tmpFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0755)
 	if err != nil {

--- a/pkg/downloads/download_test.go
+++ b/pkg/downloads/download_test.go
@@ -1,0 +1,27 @@
+package downloads
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDownloadToGopathBin(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(404)
+		}))
+		defer svr.Close()
+
+		t.Run("not found", func(t *testing.T) {
+			opts := DownloadOptions{
+				UrlTemplate: svr.URL,
+			}
+			err := DownloadToGopathBin(opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "404 Not Found")
+		})
+	})
+}


### PR DESCRIPTION
Download errors aren't returned as errors, and you need to check the status code.
