### PR TITLE
Fix tests when run on arm

### DIFF
--- a/pkg/install_test.go
+++ b/pkg/install_test.go
@@ -17,8 +17,8 @@ func TestDownloadToGopathBin(t *testing.T) {
 	require.NoError(t, err, "Failed to set up a temporary GOPATH")
 	defer cleanup()
 
-	url := "https://storage.googleapis.com/kubernetes-release/release/{{.VERSION}}/bin/{{.GOOS}}/{{.GOARCH}}/kubectl{{.EXT}}"
-	err = DownloadToGopathBin(url, "kubectl", "v1.19.0")
+	url := "https://dl.k8s.io/release/{{.VERSION}}/bin/{{.GOOS}}/{{.GOARCH}}/kubectl{{.EXT}}"
+	err = DownloadToGopathBin(url, "kubectl", "v1.23.0")
 	require.NoError(t, err)
 
 	_, err = exec.LookPath("kubectl" + xplat.FileExt())


### PR DESCRIPTION
Some of the test cases didn't have compiled binaries for arm. I've updated some tests to skip (since they exercised interesting test cases for template replacements) and updated others to more recent versions with arm binaries available.
