### PR TITLE
Use version range when checking if installed

### DIFF
--- a/ci/build_provider_example_test.go
+++ b/ci/build_provider_example_test.go
@@ -2,9 +2,14 @@ package ci_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/carolynvs/magex/ci"
 )
+
+func TestExampleDetectBuildProvider(t *testing.T) {
+	ExampleDetectBuildProvider()
+}
 
 func ExampleDetectBuildProvider() {
 	// Figure out if you are on a build provider that is supported

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,2 @@
-// Package provides helper methods for working with Magefiles (https://magefile.org)
+// Package magex provides helper methods for working with Magefiles (https://magefile.org)
 package magex

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/carolynvs/magex
 go 1.15
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/magefile/mage v1.13.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/magefile.go
+++ b/magefile.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/shx"
@@ -15,12 +17,19 @@ import (
 var Default = Test
 
 func Test() error {
+	tmpHome, err := ioutil.TempDir("", "magex")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpHome)
+
 	fmt.Println("Running tests on", xplat.DetectShell())
 	var v string
 	if mg.Verbose() {
 		v = "-v"
 	}
-	return shx.Command("go", "test", v, "./...").CollapseArgs().RunV()
+	return shx.Command("go", "test", v, "./...").CollapseArgs().
+		Env("GOPATH=" + tmpHome).RunV()
 }
 
 func EnsureMage() error {

--- a/pkg/archive/install_example_test.go
+++ b/pkg/archive/install_example_test.go
@@ -2,11 +2,16 @@ package archive_test
 
 import (
 	"log"
+	"testing"
 
 	"github.com/carolynvs/magex/pkg/archive"
 	"github.com/carolynvs/magex/pkg/downloads"
 	"github.com/carolynvs/magex/pkg/gopath"
 )
+
+func TestExampleDownloadToGopathBin(t *testing.T) {
+	ExampleDownloadToGopathBin()
+}
 
 func ExampleDownloadToGopathBin() {
 	opts := archive.DownloadArchiveOptions{

--- a/pkg/install_example_test.go
+++ b/pkg/install_example_test.go
@@ -2,10 +2,15 @@ package pkg_test
 
 import (
 	"log"
+	"testing"
 
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/pkg/gopath"
 )
+
+func TestExampleEnsureMage(t *testing.T) {
+	ExampleEnsureMage()
+}
 
 func ExampleEnsureMage() {
 	// Leave the version parameter blank to only check if it is installed, and
@@ -16,21 +21,46 @@ func ExampleEnsureMage() {
 	}
 }
 
+func TestExampleEnsurePackage(t *testing.T) {
+	ExampleEnsurePackage()
+}
+
 func ExampleEnsurePackage() {
 	// Install packr2@v2.8.0 using the command `packr2 version` to detect if the
 	// correct version is installed.
-	err := pkg.EnsurePackage("github.com/gobuffalo/packr/v2/packr2", "v2.8.0", "version")
+	err := pkg.EnsurePackage("github.com/gobuffalo/packr/v2/packr2", "v2.8.3", "version")
 	if err != nil {
 		log.Fatal("could not install packr2")
 	}
 }
 
-func ExampleInstallPackage() {
-	// Install packr2@v2.8.0
-	err := pkg.InstallPackage("github.com/gobuffalo/packr/v2/packr2", "v2.8.0")
+func TestExampleEnsurePackage_WithVersionConstraint(t *testing.T) {
+	ExampleEnsurePackage_WithVersionConstraint()
+}
+
+func ExampleEnsurePackage_WithVersionConstraint() {
+	// Install packr2@v2.8.0 using the command `packr2 version` to detect if
+	// any v2 version is installed
+	err := pkg.EnsurePackage("github.com/gobuffalo/packr/v2/packr2", "v2.8.3", "version", "2.x")
 	if err != nil {
 		log.Fatal("could not install packr2")
 	}
+}
+
+func TestExampleInstallPackage(t *testing.T) {
+	ExampleInstallPackage()
+}
+
+func ExampleInstallPackage() {
+	// Install packr2@v2.8.3
+	err := pkg.InstallPackage("github.com/gobuffalo/packr/v2/packr2", "v2.8.3")
+	if err != nil {
+		log.Fatal("could not install packr2")
+	}
+}
+
+func TestExampleDownloadToGopathBin(t *testing.T) {
+	ExampleDownloadToGopathBin()
 }
 
 func ExampleDownloadToGopathBin() {

--- a/shx/copy_example_test.go
+++ b/shx/copy_example_test.go
@@ -1,6 +1,8 @@
 package shx_test
 
-import "github.com/carolynvs/magex/shx"
+import (
+	"github.com/carolynvs/magex/shx"
+)
 
 func ExampleCopy() {
 	// Copy a file from the current directory into TEMP


### PR DESCRIPTION
When we check if a command of a specific version is available, allow the user to specify a version range, e.g. 2.x or ^1.2.4

When installing a package, default the version range check to using the default version as the minimum, e.g. ^defaultVersion. This allows any thing from the default version to the next major version.

Closes #6 