### PR TITLE
Only build main for pushes

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,9 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
 
 jobs:
   test-nix:


### PR DESCRIPTION
This avoids double building when I submit pull requests for my own branches.